### PR TITLE
✨ Feat: 에러 핸들러 및 응답 통일 설정

### DIFF
--- a/src/main/java/com/example/umc/study/UmcStudyApplication.java
+++ b/src/main/java/com/example/umc/study/UmcStudyApplication.java
@@ -2,8 +2,10 @@ package com.example.umc.study;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class UmcStudyApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/umc/study/apiPayload/BaseResponse.java
+++ b/src/main/java/com/example/umc/study/apiPayload/BaseResponse.java
@@ -1,0 +1,38 @@
+package com.example.umc.study.apiPayload;
+
+import com.example.umc.study.apiPayload.code.BaseCode;
+import com.example.umc.study.apiPayload.code.status.SuccessStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class BaseResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+
+    // 성공한 경우 응답 생성
+    public static <T> BaseResponse<T> onSuccess(T result) {
+        return new BaseResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+    }
+
+    public static <T> BaseResponse<T> of(BaseCode code, T result) {
+        return new BaseResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
+    }
+
+
+    // 실패한 경우 응답 생성
+    public static <T> BaseResponse<T> onFailure(String code, String message, T data) {
+        return new BaseResponse<>(false, code, message, data);
+    }
+}

--- a/src/main/java/com/example/umc/study/apiPayload/code/BaseCode.java
+++ b/src/main/java/com/example/umc/study/apiPayload/code/BaseCode.java
@@ -1,0 +1,6 @@
+package com.example.umc.study.apiPayload.code;
+
+public interface BaseCode {
+    public ReasonDTO getReason();
+    public ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/example/umc/study/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/com/example/umc/study/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,11 @@
+package com.example.umc.study.apiPayload.code;
+
+
+
+
+public interface BaseErrorCode {
+    public ErrorReasonDTO getReason();
+
+    public ErrorReasonDTO getReasonHttpStatus();
+
+}

--- a/src/main/java/com/example/umc/study/apiPayload/code/ErrorReasonDTO.java
+++ b/src/main/java/com/example/umc/study/apiPayload/code/ErrorReasonDTO.java
@@ -1,0 +1,15 @@
+package com.example.umc.study.apiPayload.code;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDTO {
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+    private final boolean isSuccess;
+}

--- a/src/main/java/com/example/umc/study/apiPayload/code/ReasonDTO.java
+++ b/src/main/java/com/example/umc/study/apiPayload/code/ReasonDTO.java
@@ -1,0 +1,14 @@
+package com.example.umc.study.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDTO {
+    private HttpStatus httpStatus;
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/umc/study/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/umc/study/apiPayload/code/status/ErrorStatus.java
@@ -1,0 +1,37 @@
+package com.example.umc.study.apiPayload.code.status;
+
+
+import com.example.umc.study.apiPayload.code.BaseErrorCode;
+import com.example.umc.study.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+    // 기본 에러
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder().message(message).code(code).isSuccess(false).build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/example/umc/study/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/umc/study/apiPayload/code/status/SuccessStatus.java
@@ -1,0 +1,34 @@
+package com.example.umc.study.apiPayload.code.status;
+
+import com.example.umc.study.apiPayload.code.BaseCode;
+import com.example.umc.study.apiPayload.code.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
+    _CREATED(HttpStatus.CREATED, "COMMON201", "요청 성공 및 리소스 생성됨");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder().message(message).code(code).isSuccess(true).build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/example/umc/study/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/example/umc/study/apiPayload/exception/ExceptionAdvice.java
@@ -1,0 +1,125 @@
+package com.example.umc.study.apiPayload.exception;
+
+
+import com.example.umc.study.apiPayload.BaseResponse;
+import com.example.umc.study.apiPayload.code.ErrorReasonDTO;
+import com.example.umc.study.apiPayload.code.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+
+public class ExceptionAdvice extends ResponseEntityExceptionHandler{
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
+    }
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request){
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().stream()
+                .forEach(
+                        fieldError -> {
+                            String fieldName = fieldError.getField();
+                            String errorMessage =
+                                    Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                            errors.merge(
+                                    fieldName,
+                                    errorMessage,
+                                    (existingErrorMessage, newErrorMessage) ->
+                                            existingErrorMessage + ", " + newErrorMessage);
+                        });
+
+        return handleExceptionInternalArgs(
+                e, HttpHeaders.EMPTY, ErrorStatus.valueOf("_BAD_REQUEST"), request, errors);
+    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());}
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+    ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+    return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);}
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        BaseResponse<Object> body = BaseResponse.onFailure(reason.getCode(),reason.getMessage(),null);
+//        e.printStackTrace();
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        BaseResponse<Object> body = BaseResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        BaseResponse<Object> body = BaseResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        BaseResponse<Object> body = BaseResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+}
+

--- a/src/main/java/com/example/umc/study/apiPayload/exception/GeneralException.java
+++ b/src/main/java/com/example/umc/study/apiPayload/exception/GeneralException.java
@@ -1,0 +1,17 @@
+package com.example.umc.study.apiPayload.exception;
+
+import com.example.umc.study.apiPayload.code.BaseErrorCode;
+import com.example.umc.study.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+    private BaseErrorCode code;
+
+    public ErrorReasonDTO getErrorReason() {return this.code.getReason();}
+
+    public ErrorReasonDTO getErrorReasonHttpStatus() {return this.code.getReasonHttpStatus();}
+
+}

--- a/src/main/java/com/example/umc/study/apiPayload/exception/handler/TestHandler.java
+++ b/src/main/java/com/example/umc/study/apiPayload/exception/handler/TestHandler.java
@@ -1,0 +1,10 @@
+package com.example.umc.study.apiPayload.exception.handler;
+
+import com.example.umc.study.apiPayload.code.BaseErrorCode;
+import com.example.umc.study.apiPayload.exception.GeneralException;
+
+public class TestHandler extends GeneralException {
+    public TestHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/example/umc/study/controller/TestController.java
+++ b/src/main/java/com/example/umc/study/controller/TestController.java
@@ -1,0 +1,31 @@
+package com.example.umc.study.controller;
+
+import com.example.umc.study.apiPayload.BaseResponse;
+import com.example.umc.study.service.TestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TestController {
+
+    private final TestService testService;
+
+    @GetMapping("/")
+    public BaseResponse<String> test() {
+        return BaseResponse.onSuccess("성공!");
+    }
+    @GetMapping("/failed")
+    public BaseResponse<String> failedTest() {
+        testService.faildTest();
+        return BaseResponse.onSuccess("성공!");
+    }
+    @GetMapping("/unauthorized")
+    public BaseResponse<String> unauthorized() {
+        testService.unauthorized();
+        return BaseResponse.onSuccess("성공!");
+    }
+
+
+}

--- a/src/main/java/com/example/umc/study/domain/Category.java
+++ b/src/main/java/com/example/umc/study/domain/Category.java
@@ -1,11 +1,9 @@
 package com.example.umc.study.domain;
 
+import com.example.umc.study.domain.common.BaseEntity;
 import com.example.umc.study.domain.mapping.PostCategory;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +12,8 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access =AccessLevel.PROTECTED)
 @Builder
-public class Category {
+@Getter
+public class Category extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "category_id")

--- a/src/main/java/com/example/umc/study/domain/Post.java
+++ b/src/main/java/com/example/umc/study/domain/Post.java
@@ -1,11 +1,9 @@
 package com.example.umc.study.domain;
 
+import com.example.umc.study.domain.common.BaseEntity;
 import com.example.umc.study.domain.mapping.PostCategory;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 
 import java.util.ArrayList;
@@ -15,7 +13,8 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access =AccessLevel.PROTECTED)
 @Builder
-public class Post {
+@Getter
+public class Post extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "category_id")

--- a/src/main/java/com/example/umc/study/domain/Reply.java
+++ b/src/main/java/com/example/umc/study/domain/Reply.java
@@ -1,18 +1,17 @@
 package com.example.umc.study.domain;
 
+import com.example.umc.study.domain.common.BaseEntity;
 import jakarta.persistence.*;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access =AccessLevel.PROTECTED)
 @Builder
-public class Reply {
+@Getter
+public class Reply extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "reply_id")

--- a/src/main/java/com/example/umc/study/domain/User.java
+++ b/src/main/java/com/example/umc/study/domain/User.java
@@ -1,10 +1,8 @@
 package com.example.umc.study.domain;
 
+import com.example.umc.study.domain.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,8 +11,9 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access =AccessLevel.PROTECTED)
 @Builder
+@Getter
 
-public class User {
+public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column (name = "user_id")

--- a/src/main/java/com/example/umc/study/domain/common/BaseEntity.java
+++ b/src/main/java/com/example/umc/study/domain/common/BaseEntity.java
@@ -1,0 +1,21 @@
+package com.example.umc.study.domain.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class BaseEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/umc/study/domain/mapping/PostCategory.java
+++ b/src/main/java/com/example/umc/study/domain/mapping/PostCategory.java
@@ -2,17 +2,16 @@ package com.example.umc.study.domain.mapping;
 
 import com.example.umc.study.domain.Post;
 import com.example.umc.study.domain.Category;
+import com.example.umc.study.domain.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access =AccessLevel.PROTECTED)
 @Builder
-public class PostCategory {
+@Getter
+public class PostCategory extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_category_id")

--- a/src/main/java/com/example/umc/study/service/TestService.java
+++ b/src/main/java/com/example/umc/study/service/TestService.java
@@ -1,0 +1,19 @@
+package com.example.umc.study.service;
+
+import com.example.umc.study.apiPayload.code.status.ErrorStatus;
+import com.example.umc.study.apiPayload.exception.handler.TestHandler;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TestService {
+    public void faildTest(){
+        if(1==1){
+            throw new TestHandler(ErrorStatus._BAD_REQUEST);
+        }
+    }
+    public void unauthorized(){
+        if(1 == 1){
+            throw new TestHandler(ErrorStatus._UNAUTHORIZED);
+        }
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #53

## 📌 개요


## 🔁 변경 사항
5cc08b462a01029a1e8827c0185a7e2b88b590e5
- 에러 핸들링 및 응답 통일 설정
## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

1. `@GetMapping("/")
    public BaseResponse<String> test() {
        return BaseResponse.onSuccess("성공!");
    }`
    후에 저기에 "성공!" 대신 반환값을 넣으면 될까요?

2.  error일 때는 result 값을 반환 하지 않아도 되는데 
`    @GetMapping("/failed")
    public BaseResponse<String> failedTest() {
        testService.faildTest();
        return BaseResponse.onSuccess("성공!");
    }`
    여기에 써준 이유가 궁금합니다,,!
3.  저는 기존에 success DTO 에는 result를 포함하고  error DTO에는 안했었거든요,,! 
       위 코드에 result를  썼는데도 에러일때는 result값이 반환되지 않게 해주는 설정은 http 자체일까요,,? 

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
